### PR TITLE
change stepper size from static to dynamic.

### DIFF
--- a/RPVerticalStepper/RPVerticalStepper.m
+++ b/RPVerticalStepper/RPVerticalStepper.m
@@ -44,7 +44,8 @@ float const kRPStepperHeight = kRPStepperTopButtonHeight + kRPStepperBottomButto
 // Called when the RPVerticalStepper control is set up programmatically
 - (id)initWithFrame:(CGRect)frame
 {
-    self = [super initWithFrame:CGRectMake(frame.origin.x, frame.origin.y, kRPStepperWidth, kRPStepperHeight)];
+    //self = [super initWithFrame:CGRectMake(frame.origin.x, frame.origin.y, kRPStepperWidth, kRPStepperHeight)];
+    self = [super initWithFrame: frame];
     if (self) [self setDefaultState];
     return self;
 }


### PR DESCRIPTION
Make size to dynamic. Size was kept static. As user may want to make the stepper size dynamic it was not possible previously. Made the size dynamic so that user can make it how she/he wants. 